### PR TITLE
Minor changes for paired-end sequencing data analysis

### DIFF
--- a/R/base_loadReadData.R
+++ b/R/base_loadReadData.R
@@ -193,7 +193,7 @@
 			#  strand = Rle( "*", length(greads) ) )
 			#)
       
-      suppressWarnings( greads <- readGAlignmentPairsFromBam( readfile, param = param ) )
+      suppressWarnings( greads <- readGAlignmentPairs( readfile, param = param ) )
 
       snms = seqnames(greads)
       starts = start(left(greads))

--- a/R/constructBins.R
+++ b/R/constructBins.R
@@ -178,7 +178,7 @@ constructBins <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
     			#  strand = Rle( "*", length(greads) ) )
     			#)
       
-          suppressWarnings( greads <- readGAlignmentPairsFromBam( readfile, param = param ) )
+          suppressWarnings( greads <- readGAlignmentPairs( infile, param = param ) )
     
           snms = seqnames(greads)
           starts = start(left(greads))


### PR DESCRIPTION
For paired-end data analysis, I changed to readGAlignmentPairs from readGAlignmentPairsfromBam based on "GenomicAlignment" package update. Another fix is a wrong object name, "readfile", to "infile".