### PR TITLE
Change in PET of 'generateWig.R'

### DIFF
--- a/R/generateWig.R
+++ b/R/generateWig.R
@@ -168,11 +168,11 @@ generateWig <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
     			#  strand = Rle( "*", length(greads) ) )
     			#)
       
-          suppressWarnings( greads <- readGAlignmentPairsFromBam( readfile, param = param ) )
+          suppressWarnings( greads <- readGAlignmentPairs( infile, param = param ) )
     
           snms = seqnames(greads)
-          starts = start(left(greads))
-          ends = end(right(greads))
+          starts = ifelse(strand(greads)=="+", start(greads@first), start(greads@last))
+          ends = ifelse(strand(greads)=="+", end(greads@last), end(greads@first))
           
           # remove reads with negative widths         
           idx = (starts >= ends)


### PR DESCRIPTION
'readGAlignmentPairs' replaces 'readGAlignmentPairsFromBam'.
'left' and 'right' are deprecated. 'first' and 'last' are substitutes.