### PR TITLE
Update both generateWig.R and constructBins.R

### DIFF
--- a/R/base_loadReadData.R
+++ b/R/base_loadReadData.R
@@ -196,8 +196,8 @@
       suppressWarnings( greads <- readGAlignmentPairs( readfile, param = param ) )
 
       snms = seqnames(greads)
-      starts = start(left(greads))
-      ends = end(right(greads))
+      starts = start(greads@first)
+      ends = end(greads@last)
       
       # remove reads with negative widths         
       idx = (starts >= ends)

--- a/R/base_loadReadData.R
+++ b/R/base_loadReadData.R
@@ -179,10 +179,9 @@
     # load reads corresponding to peak regions
     
     message( "Info: Reading and processing aligned read file..." )
-  
-	  param <- ScanBamParam( which=peakgrExt )
-    
+      
 	  if ( PET == FALSE ) {
+		  param <- ScanBamParam( which=peakgrExt, flag=scanBamFlag(isUnmappedQuery=FALSE))		  
 		  suppressWarnings( greads <- readGAlignments( readfile, param = param, use.names = FALSE ) )
 		  suppressWarnings( greads <- as( greads, "GRanges" ) )
 		  suppressWarnings( greads <- resize( greads, fragLen ) )
@@ -192,7 +191,7 @@
 		  #	ranges = IRanges( start=start(left(greads)), end=end(right(greads)) ),
 			#  strand = Rle( "*", length(greads) ) )
 			#)
-      
+      param <- ScanBamParam( which=peakgrExt, flag=scanBamFlag(isUnmappedQuery=FALSE, isProperPair=TRUE))            
       suppressWarnings( greads <- readGAlignmentPairs( readfile, param = param ) )
 
       snms = seqnames(greads)

--- a/R/base_loadReadData.R
+++ b/R/base_loadReadData.R
@@ -216,7 +216,7 @@
     
     # sequencing depth
     
-    seqDepth <- countBam(readfile)$records
+    seqDepth <- sum(idxstatsBam(readfile)$mapped)
   }
     
   # match reads with peaks & calculate coverage

--- a/R/base_loadReadData.R
+++ b/R/base_loadReadData.R
@@ -153,7 +153,8 @@
     
     # remove temporary files after use
     
-  
+    unlink( tempfileName[1] )
+    unlink( tempfileName[2] )
     
     gc()    
     

--- a/R/base_loadReadData.R
+++ b/R/base_loadReadData.R
@@ -153,8 +153,7 @@
     
     # remove temporary files after use
     
-    unlink( tempfileName[1] )
-    unlink( tempfileName[2] )
+  
     
     gc()    
     

--- a/R/base_loadReadData.R
+++ b/R/base_loadReadData.R
@@ -195,8 +195,8 @@
       suppressWarnings( greads <- readGAlignmentPairs( readfile, param = param ) )
 
       snms = seqnames(greads)
-      starts = start(greads@first)
-      ends = end(greads@last)
+      starts = ifelse(strand(greads)=="+", start(greads@first), start(greads@last))
+      ends = ifelse(strand(greads)=="+", end(greads@last), end(greads@first))
       
       # remove reads with negative widths         
       idx = (starts >= ends)

--- a/R/constructBins.R
+++ b/R/constructBins.R
@@ -165,9 +165,9 @@ constructBins <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
         
         # load BAM file
         
-        param <- ScanBamParam( which=GRanges( seqnames = chr, IRanges( 1, chrlen[[chr]] ) ) )
-    	  
     	  if ( PET == FALSE ) {
+         param <- ScanBamParam(which = GRanges(seqnames = chr,
+              IRanges(1, chrlen[[chr]])), flag=scanBamFlag(isUnmappedQuery=FALSE))
     		  suppressWarnings( greads <- readGAlignments( infile, param = param, use.names = FALSE ) )
     		  suppressWarnings( greads <- as( greads, "GRanges" ) )
     		  suppressWarnings( greads <- resize( greads, fragLen ) )
@@ -177,7 +177,8 @@ constructBins <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
     		  #	ranges = IRanges( start=start(left(greads)), end=end(right(greads)) ),
     			#  strand = Rle( "*", length(greads) ) )
     			#)
-      
+      param <- ScanBamParam(which = GRanges(seqnames = chr,
+          IRanges(1, chrlen[[chr]])), flag=scanBamFlag(isUnmappedQuery=FALSE, isProperPair=TRUE))      
           suppressWarnings( greads <- readGAlignmentPairs( infile, param = param ) )
     
           snms = seqnames(greads)

--- a/R/constructBins.R
+++ b/R/constructBins.R
@@ -125,7 +125,7 @@ constructBins <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
       
       # calculate sequencing depth
       
-      seqDepth <- countBam(infile)$records
+      seqDepth <- sum(idxstatsBam(infile)$mapped)
       
       # file name for genome-wide file
         

--- a/R/constructBins.R
+++ b/R/constructBins.R
@@ -181,8 +181,8 @@ constructBins <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
           suppressWarnings( greads <- readGAlignmentPairs( infile, param = param ) )
     
           snms = seqnames(greads)
-          starts = start(left(greads))
-          ends = end(right(greads))
+          starts = ifelse(strand(greads)=="+", start(greads@first), start(greads@last))
+          ends = ifelse(strand(greads)=="+", end(greads@last), end(greads@first))
           
           # remove reads with negative widths         
           idx = (starts >= ends)

--- a/R/generateWig.R
+++ b/R/generateWig.R
@@ -155,9 +155,9 @@ generateWig <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
         
         # load BAM file
         
-        param <- ScanBamParam( which=GRanges( seqnames = chr, IRanges( 1, chrlen[[chr]] ) ) )
-        
     	  if ( PET == FALSE ) {
+        param <- ScanBamParam(which = GRanges(seqnames = chr,
+              IRanges(1, chrlen[[chr]])), flag=scanBamFlag(isUnmappedQuery=FALSE))
     		  suppressWarnings( greads <- readGAlignments( infile, param = param, use.names = FALSE ) )
     		  suppressWarnings( greads <- as( greads, "GRanges" ) )
     		  suppressWarnings( greads <- resize( greads, fragLen ) )
@@ -167,7 +167,8 @@ generateWig <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
     		  #	ranges = IRanges( start=start(left(greads)), end=end(right(greads)) ),
     			#  strand = Rle( "*", length(greads) ) )
     			#)
-      
+      param <- ScanBamParam(which = GRanges(seqnames = chr,
+          IRanges(1, chrlen[[chr]])), flag=scanBamFlag(isUnmappedQuery=FALSE, isProperPair=TRUE)) #tba    
           suppressWarnings( greads <- readGAlignmentPairs( infile, param = param ) )    
               
           snms = seqnames(greads)

--- a/R/generateWig.R
+++ b/R/generateWig.R
@@ -168,7 +168,7 @@ generateWig <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
     			#  strand = Rle( "*", length(greads) ) )
     			#)
       param <- ScanBamParam(which = GRanges(seqnames = chr,
-          IRanges(1, chrlen[[chr]])), flag=scanBamFlag(isUnmappedQuery=FALSE, isProperPair=TRUE)) #tba    
+          IRanges(1, chrlen[[chr]])), flag=scanBamFlag(isUnmappedQuery=FALSE, isProperPair=TRUE))   
           suppressWarnings( greads <- readGAlignmentPairs( infile, param = param ) )    
               
           snms = seqnames(greads)

--- a/R/generateWig.R
+++ b/R/generateWig.R
@@ -168,12 +168,12 @@ generateWig <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
     			#  strand = Rle( "*", length(greads) ) )
     			#)
       
-          suppressWarnings( greads <- readGAlignmentPairsFromBam( readfile, param = param ) )
-    
+          suppressWarnings( greads <- readGAlignmentPairs( infile, param = param ) )    
+              
           snms = seqnames(greads)
-          starts = start(left(greads))
-          ends = end(right(greads))
-          
+          starts = ifelse(strand(greads)=="+", start(greads@first), start(greads@last))
+          ends = ifelse(strand(greads)=="+", end(greads@last), end(greads@first))
+              
           # remove reads with negative widths         
           idx = (starts >= ends)
           if(any(idx)){


### PR DESCRIPTION
'readGAlignmentPairs' replaces 'readGAlignmentPairsFromBam'.
'left' and 'right' are deprecated. 'first' and 'last' are substitutes.